### PR TITLE
Fix order of linker arguments in order to ensure that symbol lookup i…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 sound_meter: sound_meter.c
-	gcc -lm -lasound sound_meter.c -o sound_meter
+	gcc sound_meter.c -o sound_meter -lm -lasound


### PR DESCRIPTION
This is related to the issue #1. The problem here is that the symbol lookup will fail due to the order of the linker arguments. I reordered the arguments and confirmed that the compile will work on an Ubuntu 16.04 machine.